### PR TITLE
Migrate message transport from actix actors to NATS (async-nats 0.39)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,31 +3,6 @@
 version = 4
 
 [[package]]
-name = "actix"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cba56612922b907719d4a01cf11c8d5b458e7d3dba946d0435f20f58d6795ed2"
-dependencies = [
- "actix-macros",
- "actix-rt",
- "actix_derive",
- "bitflags 2.6.0",
- "bytes",
- "crossbeam-channel",
- "futures-core",
- "futures-sink",
- "futures-task",
- "futures-util",
- "log",
- "once_cell",
- "parking_lot",
- "pin-project-lite",
- "smallvec",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
 name = "actix-codec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,7 +89,6 @@ version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28f32d40287d3f402ae0028a9d54bef51af15c8769492826a69d28f81893151d"
 dependencies = [
- "actix-macros",
  "futures-core",
  "tokio",
 ]
@@ -206,17 +180,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f591380e2e68490b5dfaf1dd1aa0ebe78d84ba7067078512b4ea6e4492d622b8"
 dependencies = [
  "actix-router",
- "proc-macro2",
- "quote",
- "syn 2.0.87",
-]
-
-[[package]]
-name = "actix_derive"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7db3d5a9718568e4cf4a537cfd7070e6e6ff7481510d0237fb529ac850f6d3"
-dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -348,6 +311,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
+name = "async-nats"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a798aab0c0203b31d67d501e5ed1f3ac6c36a329899ce47fc93c3bea53f3ae89"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "memchr",
+ "nkeys",
+ "nuid",
+ "once_cell",
+ "pin-project",
+ "portable-atomic",
+ "rand",
+ "regex",
+ "ring",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-webpki 0.102.7",
+ "serde",
+ "serde_json",
+ "serde_nanos",
+ "serde_repr",
+ "thiserror 1.0.50",
+ "time",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tokio-websockets",
+ "tracing",
+ "tryhard",
+ "url",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,9 +449,12 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bytestring"
@@ -672,16 +674,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-queue"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,6 +706,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "der"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,6 +755,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -789,6 +814,28 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "sha2",
+ "signature",
+ "subtle",
+]
 
 [[package]]
 name = "either"
@@ -868,6 +915,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "flate2"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,6 +978,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,9 +1010,9 @@ checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.28"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -969,6 +1037,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,8 +1065,10 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1419,12 +1500,12 @@ dependencies = [
 name = "mcep"
 version = "0.1.0"
 dependencies = [
- "actix",
- "actix-rt",
  "actix-web",
+ "async-nats",
  "chrono",
  "clap",
  "config",
+ "futures",
  "http 1.0.0",
  "kafka",
  "log",
@@ -1534,6 +1615,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nkeys"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf"
+dependencies = [
+ "data-encoding",
+ "ed25519",
+ "ed25519-dalek",
+ "getrandom",
+ "log",
+ "rand",
+ "signatory",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,6 +1637,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nuid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83"
+dependencies = [
+ "rand",
 ]
 
 [[package]]
@@ -1786,6 +1891,26 @@ dependencies = [
  "once_cell",
  "pest",
  "sha2",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2050,9 +2175,21 @@ checksum = "f4ed1d73fb92eba9b841ba2aef69533a060ccc0d3ec71c90aeda5996d4afb7a9"
 
 [[package]]
 name = "regex"
-version = "1.8.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2067,9 +2204,9 @@ checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.1"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "ring"
@@ -2151,30 +2288,65 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.12"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.9",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
-name = "rustls-pki-types"
-version = "1.8.0"
+name = "rustls-native-certs"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "rustls-webpki"
 version = "0.102.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56"
+dependencies = [
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2300,6 +2472,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_nanos"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2367,6 +2559,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "signatory"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31"
+dependencies = [
+ "pkcs8",
+ "rand_core",
+ "signature",
+ "zeroize",
 ]
 
 [[package]]
@@ -2873,6 +3077,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2895,6 +3109,27 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "tokio-websockets"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "http 1.0.0",
+ "httparse",
+ "rand",
+ "ring",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2973,6 +3208,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tryhard"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,15 +5,15 @@ edition = "2021"
 
 [dependencies]
 typetag = "0.2"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "rt"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "rt", "time"] }
 toml = { version = "0.8.2" }
 serde = { version = "1.0.164" }
 serde_derive = { version = "1.0.164" }
 serde_millis = { version = "0.1.1" }
 log = { version = "0.4.20" }
 log4rs = { version = "1.2.0" }
-actix = { version = "0.13.1" }
-actix-rt = { version = "2.9.0" }
+async-nats = { version = "0.39" }
+futures = { version = "0.3" }
 chrono = { version = "0.4.31", features = ["serde"] }
 postgres-types = { version = "0.2.6", features = ["derive", "with-serde_json-1"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-native-tls", "postgres", "migrate"] }

--- a/config/dev.toml
+++ b/config/dev.toml
@@ -11,5 +11,8 @@ topics.input="input"
 topics.output="output"
 client_id="mcep-kafka"
 
+[nats]
+host="nats://localhost:4222"
+
 [logging]
 debug=false

--- a/src/api/deployment/mod.rs
+++ b/src/api/deployment/mod.rs
@@ -1,11 +1,14 @@
-use crate::runtime::engine::EngineActor;
-use crate::services::deployment::create::NewDeployment;
-use crate::services::deployment::{create, delete, get};
-use actix::Addr;
+use std::sync::Arc;
+
 use actix_web::http::StatusCode;
 use actix_web::web::{Data, Json, Path};
 use actix_web::{delete, get, post, HttpResponse};
 use sqlx::{Pool, Postgres};
+
+use crate::runtime::engine::Engine;
+use crate::services::deployment::{create, delete, get};
+use crate::services::deployment::create::NewDeployment;
+
 mod mod_test;
 
 #[get("{id}")]
@@ -20,11 +23,11 @@ pub async fn get_deployment_handler(path: Path<i32>, pool: Data<Pool<Postgres>>)
 
 #[post("")]
 pub async fn create_deployment_handler(
-    sender: Data<Addr<EngineActor>>,
+    engine: Data<Arc<Engine>>,
     pool: Data<Pool<Postgres>>,
     dep: Json<NewDeployment>,
 ) -> HttpResponse {
-    match create::create_deployment(&sender, &pool, dep.into_inner()).await {
+    match create::create_deployment(&engine, &pool, dep.into_inner()).await {
         Some(deployment) => HttpResponse::Ok().json(deployment),
         None => HttpResponse::new(StatusCode::INTERNAL_SERVER_ERROR),
     }
@@ -33,10 +36,10 @@ pub async fn create_deployment_handler(
 #[delete("{id}")]
 pub async fn delete_deployment_handler(
     path: Path<i32>,
-    sender: Data<Addr<EngineActor>>,
+    engine: Data<Arc<Engine>>,
     pool: Data<Pool<Postgres>>,
 ) -> HttpResponse {
     let id = path.into_inner();
-    let _ = delete::delete_deployment(&sender, &pool, id).await;
+    let _ = delete::delete_deployment(&engine, &pool, id).await;
     HttpResponse::new(StatusCode::OK)
 }

--- a/src/bin/mcep.rs
+++ b/src/bin/mcep.rs
@@ -1,12 +1,11 @@
-use actix::prelude::*;
 use actix_web::middleware::Logger as ActixLogger;
 use actix_web::web::Data;
-use actix_web::{rt, web, App, HttpServer};
+use actix_web::{web, App, HttpServer};
 use log::info;
 use mcep::api::{definition, deployment};
-use mcep::runtime::engine::EngineActor;
-use mcep::runtime::sink::kafka::KafkaSinkActor;
-use mcep::runtime::source::SourceActor;
+use mcep::runtime::engine::Engine;
+use mcep::runtime::sink::kafka::spawn_sink;
+use mcep::runtime::source::spawn_source;
 use mcep::types::config;
 use mcep::types::definition::Definition;
 use mcep::types::deployment::Deployment;
@@ -14,7 +13,7 @@ use mcep::{database, runtime, utils};
 use sqlx::{Pool, Postgres};
 use tokio::signal;
 
-#[actix::main]
+#[actix_web::main]
 async fn main() {
     let config = config::load().expect("config should be loaded");
     utils::configure_logger(&config.logging);
@@ -30,19 +29,34 @@ async fn main() {
         .await
         .expect("migrations failed");
 
+    let nats = async_nats::connect(&config.nats.host)
+        .await
+        .expect("nats connection failed");
+
     info!("starting sink");
-    let sink = KafkaSinkActor::new(&config.kafka).unwrap();
+    spawn_sink(&config.kafka, nats.clone())
+        .await
+        .expect("sink must start");
+
     info!("starting engine");
     let (definitions, deployments) = load(&database_connection_pool)
         .await
         .expect("database state must be loaded");
-    let engine = EngineActor::new(sink, definitions, deployments)
-        .expect("engine must start")
-        .start();
+    let engine = Engine::new(nats.clone());
+
+    {
+        let definitions_by_id: std::collections::HashMap<_, _> =
+            definitions.into_iter().map(|d| (d.id, d)).collect();
+        for dep in deployments {
+            engine
+                .deploy(&dep, &definitions_by_id)
+                .await
+                .expect("deployment must succeed");
+        }
+    }
+
     info!("starting source");
-    SourceActor::new(&config.kafka, engine.clone())
-        .unwrap()
-        .start();
+    spawn_source(&config.kafka, nats.clone()).expect("source must start");
 
     let server = HttpServer::new(move || {
         let definition_services = web::scope("/definition")
@@ -65,12 +79,11 @@ async fn main() {
             .app_data(Data::new(engine.clone()))
             .service(api)
     })
-    // .bind(("0.0.0.0", 8080))
     .bind(("127.0.0.1", 8080))
     .unwrap()
     .run();
     let server_handle = server.handle();
-    rt::spawn(server);
+    actix_web::rt::spawn(server);
     signal::ctrl_c().await.expect("failed to listen for event");
     server_handle.stop(false).await;
     info!("closing mcep");

--- a/src/runtime/engine/block/mod.rs
+++ b/src/runtime/engine/block/mod.rs
@@ -1,20 +1,23 @@
-use actix::{Actor, ActorContext, Addr, Context, Handler, Message};
+use std::collections::HashMap;
+
+use async_nats::Client;
+use futures::StreamExt;
 use log::{debug, error};
-use std::collections::{HashMap, HashSet};
+use tokio::task::JoinHandle;
 
 use crate::runtime::engine::block::code::PythonCodeBlock;
+use crate::runtime::engine::flow::block_subject;
 use crate::runtime::engine::Data;
-use crate::runtime::sink::kafka::{KafkaSinkActor, KafkaSinkActorMessage};
 use crate::runtime::{DataFrame, Name};
-use crate::types::definition::block::github::Github;
 use crate::types::definition::block::code::CodeBlock as CodeBlockDefinition;
+use crate::types::definition::block::github::Github;
 use crate::types::definition::block::{Block as BlockDefinition, BlockType};
 use crate::types::deployment::{BlockId, BlockInstanceId, DeploymentId};
 
 pub mod code;
 mod mod_test;
 
-pub trait Block {
+pub trait Block: Send {
     fn id(&self) -> BlockId;
     fn run(&mut self, df: &HashMap<Name, Data>) -> Result<Vec<DataFrame>, String>;
 }
@@ -57,77 +60,75 @@ fn as_type<T: Clone + 'static>(definition: Box<dyn BlockDefinition>) -> Result<T
     }
 }
 
-#[derive(Message)]
-#[rtype(result = "()")]
-pub enum BlockActorMessage {
-    Process(Vec<DataFrame>),
-    AddTargets(HashSet<Addr<BlockActor>>, HashSet<Addr<KafkaSinkActor>>),
-    Stop,
-}
-
-pub struct BlockActor {
-    state: HashMap<Name, Data>,
+pub fn spawn_block(
+    nats: Client,
+    deployment_id: DeploymentId,
     block: Box<dyn Block>,
-    blocks: HashSet<Addr<BlockActor>>,
-    sinks: HashSet<Addr<KafkaSinkActor>>,
+    target_block_subjects: Vec<String>,
+    target_sink_subjects: Vec<String>,
+) -> JoinHandle<()> {
+    let subject = block_subject(deployment_id, &block.id());
+    tokio::spawn(async move {
+        run_block(nats, subject, block, target_block_subjects, target_sink_subjects).await;
+    })
 }
 
-impl BlockActor {
-    pub fn new(block: Box<dyn Block>) -> BlockActor {
-        BlockActor {
-            state: HashMap::new(),
-            block,
-            blocks: HashSet::new(),
-            sinks: HashSet::new(),
+async fn run_block(
+    nats: Client,
+    subject: String,
+    mut block: Box<dyn Block>,
+    target_block_subjects: Vec<String>,
+    target_sink_subjects: Vec<String>,
+) {
+    let mut sub = match nats.subscribe(subject.clone()).await {
+        Ok(s) => s,
+        Err(e) => {
+            error!("block failed to subscribe to '{}': {}", subject, e);
+            return;
         }
-    }
+    };
 
-    pub fn add_targets(
-        &mut self,
-        blocks: HashSet<Addr<BlockActor>>,
-        sinks: HashSet<Addr<KafkaSinkActor>>,
-    ) {
-        self.blocks.extend(blocks);
-        self.sinks.extend(sinks);
-    }
+    let mut state: HashMap<Name, Data> = HashMap::new();
 
-    fn process(&mut self, data: Vec<DataFrame>) {
-        let count = data.len();
-        for frame in data {
-            self.state.insert(frame.name, frame.value);
-        }
-        let result = self.block.run(&self.state);
-        match result {
-            Ok(list) => {
-                debug!(
-                    "processed block data {} frames for block {}",
-                    count,
-                    self.block.id()
-                );
-                self.blocks.iter().for_each(|addr| {
-                    addr.do_send(BlockActorMessage::Process(list.clone()));
-                });
-                self.sinks.iter().for_each(|addr| {
-                    addr.do_send(KafkaSinkActorMessage::Send(list.clone()));
-                })
+    while let Some(msg) = sub.next().await {
+        let frames: Vec<DataFrame> = match serde_json::from_slice(&msg.payload) {
+            Ok(f) => f,
+            Err(e) => {
+                error!("block '{}' failed to deserialize frames: {}", subject, e);
+                continue;
             }
-            Err(err_string) => error!("failed to process message {}", err_string),
+        };
+
+        for frame in frames {
+            state.insert(frame.name.clone(), frame.value.clone());
+        }
+
+        match block.run(&state) {
+            Ok(output_frames) => {
+                debug!(
+                    "block '{}' produced {} output frames",
+                    subject,
+                    output_frames.len()
+                );
+                for target in &target_block_subjects {
+                    publish_frames(&nats, target, &output_frames).await;
+                }
+                for target in &target_sink_subjects {
+                    publish_frames(&nats, target, &output_frames).await;
+                }
+            }
+            Err(e) => error!("block '{}' failed to process message: {}", subject, e),
         }
     }
 }
 
-impl Actor for BlockActor {
-    type Context = Context<Self>;
-}
-
-impl Handler<BlockActorMessage> for BlockActor {
-    type Result = ();
-
-    fn handle(&mut self, msg: BlockActorMessage, ctx: &mut Self::Context) -> Self::Result {
-        match msg {
-            BlockActorMessage::Process(data) => self.process(data),
-            BlockActorMessage::AddTargets(blocks, sinks) => self.add_targets(blocks, sinks),
-            BlockActorMessage::Stop => ctx.stop(),
+async fn publish_frames(nats: &Client, subject: &str, frames: &Vec<DataFrame>) {
+    match serde_json::to_vec(frames) {
+        Ok(payload) => {
+            if let Err(e) = nats.publish(subject.to_string(), payload.into()).await {
+                error!("failed to publish frames to '{}': {}", subject, e);
+            }
         }
+        Err(e) => error!("failed to serialize frames for '{}': {}", subject, e),
     }
 }

--- a/src/runtime/engine/flow.rs
+++ b/src/runtime/engine/flow.rs
@@ -1,102 +1,40 @@
+use std::collections::{HashMap, HashSet};
+
+use async_nats::Client;
+use futures::StreamExt;
+use log::debug;
+use tokio::task::JoinHandle;
+
+use crate::runtime::engine::block::{new_block, spawn_block};
+use crate::runtime::engine::router::Router;
+use crate::runtime::DataFrame;
 use crate::types::definition::block::new_block_from_str;
 use crate::types::definition::block::Block as BlockDefinition;
 use crate::types::definition::{Definition, DefinitionId};
 use crate::types::deployment::sink::SinkId;
 use crate::types::deployment::source::SourceId;
-use crate::types::deployment::{BlockId, Deployment};
-use actix::{Actor, ActorContext, Addr, Context, Handler, Message};
-use log::debug;
-use std::collections::{HashMap, HashSet};
+use crate::types::deployment::{BlockId, Deployment, DeploymentId};
 
-use crate::runtime::engine::block::{new_block, BlockActor, BlockActorMessage};
-use crate::runtime::engine::router::Router;
-use crate::runtime::sink::kafka::KafkaSinkActor;
-use crate::runtime::DataFrame;
-
-#[derive(Message)]
-#[rtype(result = "()")]
-pub enum FlowActorMessages {
-    Process(DataFrame),
-    Stop,
+pub fn block_subject(deployment_id: DeploymentId, block_id: &BlockId) -> String {
+    format!(
+        "mcep.block.{}.{}.{}",
+        deployment_id, block_id.definition_id, block_id.id
+    )
 }
 
-pub struct FlowActor {
-    deployment_name: String,
-    blocks: HashMap<BlockId, Addr<BlockActor>>,
-    sources: HashMap<SourceId, HashSet<BlockId>>,
-    sinks: HashMap<SinkId, Addr<KafkaSinkActor>>,
-    router: Router,
+pub fn sink_subject(sink_id: &SinkId) -> String {
+    format!("mcep.sink.{}", sink_id.value)
 }
 
-impl FlowActor {
-    pub fn new(
-        deployment: &Deployment,
-        definitions: &HashMap<DefinitionId, Definition>,
-        sinks: HashMap<SinkId, Addr<KafkaSinkActor>>,
-    ) -> Result<Addr<FlowActor>, String> {
-        let router = Router::new(&deployment.connections);
-        let blocks: HashMap<BlockId, Addr<BlockActor>> =
-            create_block_actors(deployment, definitions)?;
-        let flow_actor = FlowActor {
-            deployment_name: deployment.name.clone(),
-            blocks,
-            sources: router.source_targets(),
-            sinks,
-            router,
-        };
-        Ok(flow_actor.start())
-    }
-
-    fn process(&self, df: &DataFrame) {
-        match &df.origin.source {
-            Some(source_id) => {
-                debug!(
-                    "processing '{:?}' for deployment '{}'",
-                    df, self.deployment_name
-                );
-                self.send_from_source(source_id, df)
-            }
-            _ => {}
-        }
-    }
-
-    fn send_from_source(&self, source_id: &SourceId, df: &DataFrame) {
-        let block_ids = self
-            .sources
-            .get(&source_id)
-            .unwrap_or(&HashSet::new())
-            .clone();
-        block_ids.iter().for_each(|block_id| {
-            self.blocks.get(block_id).iter().for_each(|addr| {
-                let frames = Vec::from([df.clone()]);
-                addr.do_send(BlockActorMessage::Process(frames));
-            })
-        });
-    }
-
-    fn stop_workers(&mut self) {
-        self.blocks.iter().for_each(|(_, addr)| {
-            let _ = addr.do_send(BlockActorMessage::Stop);
-        });
-    }
-}
-
-fn option_to_set<T: Actor>(opt: Option<&Addr<T>>) -> HashSet<Addr<T>> {
-    match opt {
-        Some(v) => {
-            let mut set = HashSet::new();
-            set.insert(v.clone());
-            set
-        }
-        None => HashSet::new(),
-    }
-}
-
-fn create_block_actors(
+pub async fn spawn_flow(
+    nats: &Client,
     deployment: &Deployment,
     definitions: &HashMap<DefinitionId, Definition>,
-) -> Result<HashMap<BlockId, Addr<BlockActor>>, String> {
-    let mut blocks: HashMap<BlockId, Addr<BlockActor>> = HashMap::new();
+) -> Result<Vec<JoinHandle<()>>, String> {
+    let router = Router::new(&deployment.connections);
+    let deployment_id = deployment.id;
+    let mut handles = Vec::new();
+
     for deployed_block in deployment.blocks.iter() {
         let definition = definitions
             .get(&deployed_block.definition_id)
@@ -104,49 +42,89 @@ fn create_block_actors(
         let body = definition.body.to_string();
         let block_definition: Box<dyn BlockDefinition> = new_block_from_str(body.as_str())?;
         let block = new_block(block_definition, deployment.id, deployed_block.id)?;
-        let block_actor = BlockActor::new(block);
-        blocks.insert(deployed_block.id(), block_actor.start());
-    }
-    Ok(blocks)
-}
+        let block_id = deployed_block.id();
 
-fn init_actors(
-    blocks: &HashMap<BlockId, Addr<BlockActor>>,
-    router: &Router,
-    sinks: &HashMap<SinkId, Addr<KafkaSinkActor>>,
-) {
-    for (block_id, block) in blocks.iter() {
-        let target_blocks: HashSet<Addr<BlockActor>> = router
+        let target_block_subjects: Vec<String> = router
             .block_targets(&block_id)
             .iter()
-            .flat_map(|target| option_to_set(blocks.get(target)))
+            .map(|bid| block_subject(deployment_id, bid))
             .collect();
-        let sink_blocks = router
+        let target_sink_subjects: Vec<String> = router
             .sink_targets(&block_id)
             .iter()
-            .flat_map(|target| option_to_set(sinks.get(target)))
+            .map(sink_subject)
             .collect();
-        let msg = BlockActorMessage::AddTargets(target_blocks, sink_blocks);
-        block.do_send(msg);
+
+        let handle = spawn_block(
+            nats.clone(),
+            deployment_id,
+            block,
+            target_block_subjects,
+            target_sink_subjects,
+        );
+        handles.push(handle);
     }
+
+    let sources = router.source_targets();
+    let deployment_name = deployment.name.clone();
+    let nats_clone = nats.clone();
+    let flow_handle = tokio::spawn(async move {
+        run_flow(nats_clone, deployment_id, deployment_name, sources).await;
+    });
+    handles.push(flow_handle);
+
+    Ok(handles)
 }
-impl Actor for FlowActor {
-    type Context = Context<Self>;
 
-    fn started(&mut self, _ctx: &mut Self::Context) {
-        init_actors(&self.blocks, &self.router, &self.sinks);
-    }
-}
+async fn run_flow(
+    nats: Client,
+    deployment_id: DeploymentId,
+    deployment_name: String,
+    sources: HashMap<SourceId, HashSet<BlockId>>,
+) {
+    let mut sub = match nats.subscribe("mcep.frames").await {
+        Ok(s) => s,
+        Err(e) => {
+            log::error!(
+                "flow '{}' failed to subscribe to mcep.frames: {}",
+                deployment_name,
+                e
+            );
+            return;
+        }
+    };
 
-impl Handler<FlowActorMessages> for FlowActor {
-    type Result = ();
+    while let Some(msg) = sub.next().await {
+        let df: DataFrame = match serde_json::from_slice(&msg.payload) {
+            Ok(df) => df,
+            Err(e) => {
+                log::error!("flow '{}' failed to deserialize DataFrame: {}", deployment_name, e);
+                continue;
+            }
+        };
 
-    fn handle(&mut self, msg: FlowActorMessages, ctx: &mut Self::Context) -> Self::Result {
-        match msg {
-            FlowActorMessages::Process(df) => self.process(&df),
-            FlowActorMessages::Stop => {
-                self.stop_workers();
-                ctx.stop()
+        debug!("flow '{}' processing {:?}", deployment_name, df);
+
+        if let Some(source_id) = &df.origin.source {
+            if let Some(block_ids) = sources.get(source_id) {
+                for block_id in block_ids {
+                    let subject = block_subject(deployment_id, block_id);
+                    let payload = match serde_json::to_vec(&vec![df.clone()]) {
+                        Ok(p) => p,
+                        Err(e) => {
+                            log::error!("flow '{}' failed to serialize frame: {}", deployment_name, e);
+                            continue;
+                        }
+                    };
+                    if let Err(e) = nats.publish(subject.clone(), payload.into()).await {
+                        log::error!(
+                            "flow '{}' failed to publish to block {}: {}",
+                            deployment_name,
+                            subject,
+                            e
+                        );
+                    }
+                }
             }
         }
     }

--- a/src/runtime/engine/mod.rs
+++ b/src/runtime/engine/mod.rs
@@ -1,21 +1,19 @@
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
+use std::sync::Arc;
 
-use actix::dev::{MessageResponse, OneshotSender};
-use actix::{Actor, Addr, Context, Handler, Message};
-use log::error;
+use async_nats::Client;
 use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
 
 use crate::types::definition::{Definition, DefinitionId};
-use crate::types::deployment::sink::SinkId;
 use crate::types::deployment::{Deployment, DeploymentId};
 
-use crate::runtime::engine::flow::{FlowActor, FlowActorMessages};
-use crate::runtime::sink::kafka::KafkaSinkActor;
-use crate::runtime::DataFrame;
+use crate::runtime::engine::flow::spawn_flow;
 
 mod block;
-mod flow;
+pub mod flow;
 pub mod router;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -33,6 +31,7 @@ impl AsRef<Data> for Data {
         return &self;
     }
 }
+
 impl Hash for Data {
     fn hash<H: Hasher>(&self, state: &mut H) {
         match self {
@@ -46,115 +45,33 @@ impl Hash for Data {
     }
 }
 
-#[derive(Message)]
-#[rtype(result = "EngineActorResponse")]
-pub enum EngineActorMessage {
-    Deploy(Deployment, Vec<Definition>),
-    Undeploy(Deployment),
-    Process(DataFrame),
+pub struct Engine {
+    nats: Client,
+    deployments: Mutex<HashMap<DeploymentId, Vec<JoinHandle<()>>>>,
 }
 
-pub enum EngineActorResponse {
-    Succeed,
-    Failed(String),
-}
-
-impl<A, M> MessageResponse<A, M> for EngineActorResponse
-where
-    A: Actor,
-    M: Message<Result = EngineActorResponse>,
-{
-    fn handle(self, _ctx: &mut A::Context, tx: Option<OneshotSender<M::Result>>) {
-        if let Some(tx) = tx {
-            let _ = tx.send(self);
-        }
+impl Engine {
+    pub fn new(nats: Client) -> Arc<Engine> {
+        Arc::new(Engine {
+            nats,
+            deployments: Mutex::new(HashMap::new()),
+        })
     }
-}
 
-pub struct EngineActor {
-    flows: HashMap<DeploymentId, Addr<FlowActor>>,
-    sinks: HashMap<SinkId, Addr<KafkaSinkActor>>,
-}
-
-impl EngineActor {
-    pub fn new(
-        sinks: HashMap<SinkId, Addr<KafkaSinkActor>>,
-        definitions: Vec<Definition>,
-        deployments: Vec<Deployment>,
-    ) -> Result<EngineActor, String> {
-        let definitions_by_id: HashMap<DefinitionId, Definition> = definitions
-            .into_iter()
-            .map(|definition| (definition.id, definition))
-            .collect();
-        let deployments_by_id: HashMap<DeploymentId, Deployment> = deployments
-            .into_iter()
-            .map(|deployment| (deployment.id, deployment))
-            .collect();
-        let flows: Result<HashMap<DeploymentId, Addr<FlowActor>>, String> = deployments_by_id
-            .into_iter()
-            .map(|(deployment_id, deployment)| {
-                FlowActor::new(&deployment, &definitions_by_id, sinks.clone())
-                    .map(|flow| (deployment_id, flow))
-            })
-            .collect();
-        let engine = EngineActor {
-            flows: flows?,
-            sinks,
-        };
-        Ok(engine)
-    }
-    fn deploy(
-        &mut self,
+    pub async fn deploy(
+        &self,
         deployment: &Deployment,
         definitions: &HashMap<DefinitionId, Definition>,
     ) -> Result<(), String> {
-        let flow_actor = FlowActor::new(deployment, definitions, self.sinks.clone())?;
-        self.flows.insert(deployment.id, flow_actor);
+        let handles = spawn_flow(&self.nats, deployment, definitions).await?;
+        self.deployments.lock().await.insert(deployment.id, handles);
         Ok(())
     }
 
-    fn undeploy(&mut self, deployment: &Deployment) {
-        let removed = self.flows.remove(&deployment.id);
-        removed.iter().for_each(|addr| {
-            let _ = addr.send(FlowActorMessages::Stop);
-        })
-    }
-
-    fn process(&mut self, df: DataFrame) {
-        self.flows.iter().for_each(|(_, addr)| {
-            addr.do_send(FlowActorMessages::Process(df.clone()));
-        })
-    }
-}
-
-impl Actor for EngineActor {
-    type Context = Context<Self>;
-}
-
-impl Handler<EngineActorMessage> for EngineActor {
-    type Result = EngineActorResponse;
-
-    fn handle(&mut self, msg: EngineActorMessage, _ctx: &mut Self::Context) -> Self::Result {
-        match msg {
-            EngineActorMessage::Process(df) => {
-                self.process(df);
-                EngineActorResponse::Succeed
-            }
-            EngineActorMessage::Deploy(deployment, definitions) => {
-                let definition_map: HashMap<DefinitionId, Definition> =
-                    definitions.into_iter().map(|def| (def.id, def)).collect();
-                let result = self.deploy(&deployment, &definition_map);
-                match result {
-                    Ok(()) => EngineActorResponse::Succeed,
-                    Err(err) => {
-                        error!("engine actor error {}", err);
-                        EngineActorResponse::Failed(err)
-                    }
-                }
-            }
-            EngineActorMessage::Undeploy(deployment) => {
-                self.undeploy(&deployment);
-                EngineActorResponse::Succeed
+    pub async fn undeploy(&self, deployment: &Deployment) {
+        if let Some(handles) = self.deployments.lock().await.remove(&deployment.id) {
+            for handle in handles {
+                handle.abort();
             }
         }
     }

--- a/src/runtime/sink/kafka.rs
+++ b/src/runtime/sink/kafka.rs
@@ -1,64 +1,68 @@
-use actix::{Actor, Addr, Context, Handler, Message};
+use std::time::Duration;
+
+use async_nats::Client;
+use futures::StreamExt;
 use log::error;
 use rdkafka::producer::{BaseProducer, BaseRecord};
 use rdkafka::ClientConfig;
-use std::collections::HashMap;
-use std::time::Duration;
+use tokio::task::JoinHandle;
 
+use crate::runtime::engine::flow::sink_subject;
+use crate::runtime::{DataFrame, Message as DataMessage};
 use crate::types::config::Kafka;
 use crate::types::deployment::sink::SinkId;
-
-use crate::runtime::{DataFrame, Message as DataMessage};
 use crate::utils;
 
-#[derive(Message)]
-#[rtype(result = "()")]
-pub enum KafkaSinkActorMessage {
-    Send(Vec<DataFrame>),
+pub async fn spawn_sink(
+    cfg: &Kafka,
+    nats: Client,
+) -> Result<(SinkId, JoinHandle<()>), String> {
+    let producer: BaseProducer = ClientConfig::new()
+        .set("bootstrap.servers", &cfg.host_list().join(","))
+        .set("client.id", &cfg.client_id)
+        .create()
+        .map_err(|e| e.to_string())?;
+
+    let sink_id = cfg.sink_id();
+    let subject = sink_subject(&sink_id);
+    let topic = cfg.topics.output.clone();
+
+    let handle = tokio::spawn(async move {
+        run_sink(nats, subject, topic, producer).await;
+    });
+
+    Ok((sink_id, handle))
 }
 
-pub struct KafkaSinkActor {
-    topic: String,
-    producer: BaseProducer,
-}
+async fn run_sink(nats: Client, subject: String, topic: String, producer: BaseProducer) {
+    let mut sub = match nats.subscribe(subject.clone()).await {
+        Ok(s) => s,
+        Err(e) => {
+            error!("sink failed to subscribe to '{}': {}", subject, e);
+            return;
+        }
+    };
 
-impl KafkaSinkActor {
-    pub fn new(cfg: &Kafka) -> Result<HashMap<SinkId, Addr<KafkaSinkActor>>, String> {
-        let producer: BaseProducer = ClientConfig::new()
-            .set("bootstrap.servers", &cfg.host_list().join(","))
-            .set("client.id", &cfg.client_id)
-            .create()
-            .map_err(|e| e.to_string())?;
-        let actor = KafkaSinkActor {
-            topic: cfg.topics.output.clone(),
-            producer,
+    while let Some(msg) = sub.next().await {
+        let frames: Vec<DataFrame> = match serde_json::from_slice(&msg.payload) {
+            Ok(f) => f,
+            Err(e) => {
+                error!("sink '{}' failed to deserialize frames: {}", subject, e);
+                continue;
+            }
         };
-        let as_map: HashMap<SinkId, Addr<KafkaSinkActor>> =
-            HashMap::from([(cfg.sink_id(), actor.start())]);
-        Ok(as_map)
-    }
-}
 
-impl Actor for KafkaSinkActor {
-    type Context = Context<Self>;
-}
-
-impl Handler<KafkaSinkActorMessage> for KafkaSinkActor {
-    type Result = ();
-
-    fn handle(&mut self, msg: KafkaSinkActorMessage, _ctx: &mut Self::Context) -> Self::Result {
-        match msg {
-            KafkaSinkActorMessage::Send(frames) => {
-                let records: Vec<(String, String)> =
-                    frames_to_record(&frames).expect("convert frames"); // todo - error handling
+        match frames_to_record(&frames) {
+            Ok(records) => {
                 for (key, payload) in records {
-                    let record = BaseRecord::to(&self.topic).key(&key).payload(&payload);
-                    if let Err((err, _record)) = self.producer.send(record) {
-                        error!("failed to send record {}", err);
+                    let record = BaseRecord::to(&topic).key(&key).payload(&payload);
+                    if let Err((err, _)) = producer.send(record) {
+                        error!("sink failed to send record: {}", err);
                     }
                 }
-                self.producer.poll(Duration::from_millis(0));
+                producer.poll(Duration::from_millis(0));
             }
+            Err(e) => error!("sink failed to convert frames to records: {}", e),
         }
     }
 }
@@ -72,17 +76,15 @@ pub fn frames_to_record(frames: &Vec<DataFrame>) -> Result<Vec<(String, String)>
     Ok(records)
 }
 
-pub fn messages_to_records<'a>(
-    messages: &Vec<DataMessage>,
-) -> Result<Vec<(String, String)>, String> {
+pub fn messages_to_records(messages: &Vec<DataMessage>) -> Result<Vec<(String, String)>, String> {
     let mut records: Vec<(String, String)> = Vec::new();
     for message in messages {
-        records.push(message_to_record(&message)?);
+        records.push(message_to_record(message)?);
     }
     Ok(records)
 }
 
-pub fn message_to_record<'a>(msg: &DataMessage) -> Result<(String, String), String> {
+pub fn message_to_record(msg: &DataMessage) -> Result<(String, String), String> {
     let key = msg.key().to_string();
     let value = msg.as_json().map_err(utils::to_string)?;
     Ok((key, value))

--- a/src/runtime/source/mod.rs
+++ b/src/runtime/source/mod.rs
@@ -1,58 +1,42 @@
-use crate::runtime::engine::{EngineActor, EngineActorMessage};
+use async_nats::Client;
+use log::error;
+use tokio::task::JoinHandle;
+
 use crate::runtime::source::kafka::KafkaSource;
 use crate::runtime::DataFrame;
 use crate::types::config::Kafka;
-use actix::{Actor, Addr, AsyncContext, Context, Handler, Message};
-use std::time::Duration;
 
 pub mod kafka;
 
-pub trait Source {
+pub trait Source: Send {
     fn fetch(&mut self) -> Result<Vec<DataFrame>, String>;
 }
 
-#[derive(Message)]
-#[rtype(result = "()")]
-pub enum SourceActorMessage {
-    Poll,
+pub fn spawn_source(cfg: &Kafka, nats: Client) -> Result<JoinHandle<()>, String> {
+    let source = KafkaSource::new(cfg)?;
+    let handle = tokio::spawn(async move {
+        run_source(nats, source).await;
+    });
+    Ok(handle)
 }
 
-pub struct SourceActor {
-    source: Box<dyn Source>,
-    engine: Addr<EngineActor>,
-}
-
-impl SourceActor {
-    pub fn new(cfg: &Kafka, engine: Addr<EngineActor>) -> Result<SourceActor, String> {
-        let source = KafkaSource::new(cfg)?;
-        Ok(SourceActor { source, engine })
-    }
-}
-
-impl Actor for SourceActor {
-    type Context = Context<Self>;
-
-    fn started(&mut self, ctx: &mut Self::Context) {
-        ctx.run_interval(
-            Duration::from_millis(1000),
-            |_, c: &mut Context<SourceActor>| {
-                let _ = c.address().do_send(SourceActorMessage::Poll);
-            },
-        );
-    }
-}
-
-impl Handler<SourceActorMessage> for SourceActor {
-    type Result = ();
-
-    fn handle(&mut self, msg: SourceActorMessage, _ctx: &mut Self::Context) -> Self::Result {
-        match msg {
-            SourceActorMessage::Poll => {
-                let frames = self.source.fetch().unwrap();
-                frames.into_iter().for_each(|frame| {
-                    self.engine.do_send(EngineActorMessage::Process(frame));
-                })
+async fn run_source(nats: Client, mut source: Box<dyn Source>) {
+    loop {
+        match source.fetch() {
+            Ok(frames) => {
+                for frame in frames {
+                    match serde_json::to_vec(&frame) {
+                        Ok(payload) => {
+                            if let Err(e) = nats.publish("mcep.frames", payload.into()).await {
+                                error!("source failed to publish frame: {}", e);
+                            }
+                        }
+                        Err(e) => error!("source failed to serialize frame: {}", e),
+                    }
+                }
             }
+            Err(e) => error!("source fetch error: {}", e),
         }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
 }

--- a/src/services/deployment/create.rs
+++ b/src/services/deployment/create.rs
@@ -1,17 +1,17 @@
-use crate::runtime::engine::{EngineActor, EngineActorMessage, EngineActorResponse};
+use std::collections::HashSet;
+
+use log::{error, info};
+use serde_derive::Deserialize;
+use sqlx::types::Json;
+use sqlx::{Pool, Postgres};
+
+use crate::runtime::engine::Engine;
+use crate::services::definition::get::get_definitions;
 use crate::types::definition::DefinitionId;
 use crate::types::deployment::connection::BlockConnection;
 use crate::types::deployment::sink::Sink;
 use crate::types::deployment::source::Source;
 use crate::types::deployment::{DeployedBlock, Deployment};
-use actix::Addr;
-use log::{error, info};
-use serde_derive::Deserialize;
-use sqlx::types::Json;
-use sqlx::{Pool, Postgres};
-use std::collections::HashSet;
-
-use crate::services::definition::get::get_definitions;
 use crate::utils;
 
 #[derive(Deserialize)]
@@ -25,7 +25,7 @@ pub struct NewDeployment {
 }
 
 pub async fn create_deployment(
-    sender: &Addr<EngineActor>,
+    engine: &Engine,
     pool: &Pool<Postgres>,
     new_deployment: NewDeployment,
 ) -> Option<Deployment> {
@@ -40,27 +40,24 @@ pub async fn create_deployment(
         .await
         .map_err(utils::log_and_convert_to_string)
         .ok()?;
+
     let definition_ids: HashSet<DefinitionId> = deployment.definition_ids();
     let definitions = get_definitions(pool, definition_ids)
         .await
         .map_err(utils::log_and_convert_to_string)
         .ok()?;
-    info!("deployment {} created", deployment.id.to_string());
-    let response = sender
-        .send(EngineActorMessage::Deploy(deployment.clone(), definitions))
-        .await
-        .ok()?;
-    match response {
-        EngineActorResponse::Succeed => {
-            info!("deployment {} deployed", deployment.id.to_string());
+
+    info!("deployment {} created", deployment.id);
+
+    let definitions_map: std::collections::HashMap<_, _> =
+        definitions.into_iter().map(|d| (d.id, d)).collect();
+    match engine.deploy(&deployment, &definitions_map).await {
+        Ok(()) => {
+            info!("deployment {} deployed", deployment.id);
             Some(deployment)
         }
-        EngineActorResponse::Failed(err) => {
-            error!(
-                "deployment {} not deployed due to {}",
-                deployment.id.to_string(),
-                err
-            );
+        Err(err) => {
+            error!("deployment {} not deployed: {}", deployment.id, err);
             None
         }
     }

--- a/src/services/deployment/delete.rs
+++ b/src/services/deployment/delete.rs
@@ -1,28 +1,21 @@
-use crate::runtime::engine::{EngineActor, EngineActorMessage};
+use sqlx::{Pool, Postgres};
+
+use crate::runtime::engine::Engine;
 use crate::services::deployment::get;
-use crate::types::deployment::DeploymentId;
-use actix::Addr;
-use sqlx::{Error, Pool, Postgres};
 
 pub async fn delete_deployment(
-    sender: &Addr<EngineActor>,
+    engine: &Engine,
     pool: &Pool<Postgres>,
-    id: DeploymentId,
+    id: i32,
 ) -> Result<(), String> {
-    let result = get::get_deployment(&pool, id).await;
-    match result {
-        Ok(deployment) => {
-            sender
-                .send(EngineActorMessage::Undeploy(deployment))
-                .await
-                .expect("TODO: panic message");
-            let delete_result: Result<(), Error> =
-                sqlx::query_as::<_, _>("DELETE FROM deployments WHERE id = $1")
-                    .bind(id)
-                    .fetch_one(pool)
-                    .await;
-            delete_result.map_err(|err| err.to_string())
-        }
-        Err(err) => Err(err.to_string()),
-    }
+    let deployment = get::get_deployment(pool, id)
+        .await
+        .map_err(|e| e.to_string())?;
+    engine.undeploy(&deployment).await;
+    sqlx::query("DELETE FROM deployments WHERE id = $1")
+        .bind(id)
+        .execute(pool)
+        .await
+        .map(|_| ())
+        .map_err(|e| e.to_string())
 }

--- a/src/types/config/mod.rs
+++ b/src/types/config/mod.rs
@@ -8,7 +8,13 @@ use serde_derive::{Deserialize, Serialize};
 pub struct App {
     pub database: Database,
     pub kafka: Kafka,
+    pub nats: Nats,
     pub logging: Logging,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Nats {
+    pub host: String,
 }
 
 #[derive(Clone, Serialize, Deserialize)]

--- a/src/types/deployment/sink.rs
+++ b/src/types/deployment/sink.rs
@@ -4,7 +4,7 @@ use sqlx::FromRow;
 
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub struct SinkId {
-    value: String,
+    pub value: String,
 }
 
 impl From<&str> for SinkId {


### PR DESCRIPTION
Replace actix/actix-rt actor system with NATS pub/sub:
- EngineActor → Arc<Engine> with tokio::sync::Mutex
- FlowActor → tokio task subscribing to mcep.frames
- BlockActor → tokio task subscribing to mcep.block.{dep_id}.{def_id}.{inst_id}
- KafkaSinkActor → tokio task subscribing to mcep.sink.{sink_id}
- SourceActor → tokio task publishing to mcep.frames